### PR TITLE
SubgroupsSolvableGroup: honor retnorm for trivial groups

### DIFF
--- a/lib/grppclat.gi
+++ b/lib/grppclat.gi
@@ -570,9 +570,6 @@ local g,	# group
       xo;	# xternal orbits
 
   g:=arg[1];
-  if Size(g)=1 then
-    return [g];
-  fi;
   if Length(arg)>1 and IsRecord(arg[Length(arg)]) then
     opt:=arg[Length(arg)];
   else
@@ -580,14 +577,23 @@ local g,	# group
   fi;
 
   # parse options
+  retnorm:=IsBound(opt.retnorm) and opt.retnorm;
+
+  # handle trivial case
+  if IsTrivial(g) then
+    if retnorm then
+       return [[g],[g]];
+    else
+       return [g];
+    fi;
+  fi;
+
   normal:=IsBound(opt.normal) and opt.normal=true;
   if IsBound(opt.consider) then 
     consider:=opt.consider;
   else
     consider:=false;
   fi;
-
-  retnorm:=IsBound(opt.retnorm) and opt.retnorm;
 
   isom:=fail;
 

--- a/tst/testbugfix/2022-05-10-SubgroupsSolvableGroup.tst
+++ b/tst/testbugfix/2022-05-10-SubgroupsSolvableGroup.tst
@@ -1,0 +1,9 @@
+# Verify SubgroupsSolvableGroup honor retnorm=true if the
+# input is a trivial group.
+# See https://github.com/gap-system/gap/pull/4855
+gap> G:=TrivialGroup(IsPermGroup);
+Group(())
+gap> SubgroupsSolvableGroup(G);
+[ Group(()) ]
+gap> SubgroupsSolvableGroup(G, rec(retnorm:=true));
+[ [ Group(()) ], [ Group(()) ] ]


### PR DESCRIPTION
The function `SubgroupsSolvableGroup` with a trivial group as argument did not return the list of normalizers when called with the option `retnorm`.

Please provide a short summary of this PR and its purpose here. E.g., does it add a new feature, and which? Does it fix a bug, and which? If there is an associated issue, please list it here.

## Text for release notes

We track noteworthy changes as entries in the `CHANGES.md` file in the root directory of this repository. To help us decide whether and how to describe your PR, please do one of the following:

1. If this PR shall **not** be mentioned in the release notes, write "none" here.
2. If a brief note suffices, edit the title of this PR to be usable as entry in `CHANGES.md`, and write "see title" here (or if you have the required permissions, add the label `release notes: use title` to this PR and remove this section)
3. If a longer note is needed, just write it here, ideally following the general style used in that file

## Further details

If necessary, provide further details down here.
